### PR TITLE
Increase healthcheck timeout to 60s

### DIFF
--- a/docker-compose.mongo.yaml
+++ b/docker-compose.mongo.yaml
@@ -22,6 +22,7 @@ services:
     - MONGO_INITDB_DATABASE=db
     healthcheck:
       test: ["CMD-SHELL", "mongo --eval 'db.runCommand(\"ping\").ok' localhost:27017/test --quiet"]
+      timeout: 60s
 
   mongo-express:
     container_name: ddev-${DDEV_SITENAME}-mongo-express


### PR DESCRIPTION
Nightly build has occasionally been failing, but retry succeeds. Trying to see if increasing timeout from default 30s to 60s will resolve this.