### PR TITLE
Update for ddev head, #ddev-generated

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: tests
 on:
   pull_request:
   push:
-    branches: [ master, main ]
+    branches: [ main ]
 
   schedule:
   - cron: '01 07 * * *'
@@ -29,8 +29,8 @@ jobs:
 
     strategy:
       matrix:
-        ddev_version: [stable, edge, HEAD]
-#        ddev_version: [PR]
+        ddev_version: [stable, HEAD]
+#        ddev_version: [stable, edge, HEAD, PR]
       fail-fast: false
 
     runs-on: ubuntu-20.04

--- a/docker-compose.mongo.yaml
+++ b/docker-compose.mongo.yaml
@@ -1,3 +1,4 @@
+#ddev-generated
 version: '3.6'
 
 services:

--- a/install.yaml
+++ b/install.yaml
@@ -1,7 +1,7 @@
 name: mongo
 
 pre_install_actions:
-- 'printf "webimage_extra_packages: [php${DDEV_PHP_VERSION}-mongodb]" >.ddev/config.mongo.yaml'
+- 'printf "#ddev-generated\nwebimage_extra_packages: [php${DDEV_PHP_VERSION}-mongodb]" >.ddev/config.mongo.yaml'
 
 # list of files and directories listed that are copied into project .ddev directory
 project_files:


### PR DESCRIPTION
Latest HEAD of ddev won't overwrite files that don't have #ddev-generated in them. So we need to have it in there.