### PR TITLE
override `DDEV_DATABASE_FAMILY`

### DIFF
--- a/docker-compose.mongo.yaml
+++ b/docker-compose.mongo.yaml
@@ -42,6 +42,9 @@ services:
       HTTP_EXPOSE: "9091:8081"
     depends_on:
       - mongo
+  web:
+    environment:
+      - DDEV_DATABASE_FAMILY=mongodb
 
 volumes:
   mongo:


### PR DESCRIPTION
This PR sets the overrides the web contains `DDEV_DATABASE_FAMILY`, setting it to `mongodb`.

`DDEV_DATABASE_FAMILY` was introduced in https://github.com/ddev/ddev/pull/4991 .

