### PR TITLE
Remove anonymous volume for /data/configdb

### DIFF
--- a/docker-compose.mongo.yaml
+++ b/docker-compose.mongo.yaml
@@ -14,6 +14,11 @@ services:
       target: "/data/db"
       volume:
         nocopy: true
+    - type: "volume"
+      source: mongo-config
+      target: "/data/configdb"
+      volume:
+        nocopy: true
     - ".:/mnt/ddev_config"
     restart: "no"
     expose:
@@ -50,3 +55,4 @@ services:
 
 volumes:
   mongo:
+  mongo-config:


### PR DESCRIPTION
## The Issue

`/data/configdb` doesn't survive `ddev restart`.

## How This PR Solves The Issue

Adds a named volume for it.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

