### PR TITLE
Bump mongo-express, update config, do not expand php version, fixes #16

### DIFF
--- a/docker-compose.mongo.yaml
+++ b/docker-compose.mongo.yaml
@@ -29,14 +29,15 @@ services:
     environment:
     - MONGO_INITDB_ROOT_USERNAME=db
     - MONGO_INITDB_ROOT_PASSWORD=db
-    - MONGO_INITDB_DATABASE=db
+    # See https://github.com/docker-library/docs/tree/master/mongo#mongo_initdb_database
+    # - MONGO_INITDB_DATABASE=db
     healthcheck:
       test: ["CMD-SHELL", "mongo --eval 'db.runCommand(\"ping\").ok' localhost:27017/test --quiet"]
       timeout: 60s
 
   mongo-express:
     container_name: ddev-${DDEV_SITENAME}-mongo-express
-    image: mongo-express:0.54
+    image: mongo-express:1.0
     restart: "no"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
@@ -46,9 +47,11 @@ services:
     - "8081"
     environment:
       VIRTUAL_HOST: $DDEV_HOSTNAME
-      ME_CONFIG_MONGODB_ADMINUSERNAME: db
-      ME_CONFIG_MONGODB_ADMINPASSWORD: db
+      ME_CONFIG_MONGODB_ENABLE_ADMIN: "true"
+      ME_CONFIG_BASICAUTH: "false"
+      ME_CONFIG_MONGODB_URL: "mongodb://db:db@mongo:27017"
       HTTP_EXPOSE: "9091:8081"
+      HTTPS_EXPOSE: "9092:8081"
     depends_on:
       - mongo
     entrypoint: [sh, -c, "sleep 5s && tini -- /docker-entrypoint.sh mongo-express"]

--- a/install.yaml
+++ b/install.yaml
@@ -3,7 +3,7 @@ name: mongo
 pre_install_actions:
 - |
   #ddev-description:Create config.mongo.yaml with webimage_extra_packages in it
-  printf "#ddev-generated\nwebimage_extra_packages: [php${DDEV_PHP_VERSION}-mongodb]" >.ddev/config.mongo.yaml
+  printf '#ddev-generated\nwebimage_extra_packages: ["php${DDEV_PHP_VERSION}-mongodb"]\n' >.ddev/config.mongo.yaml
 
 # list of files and directories listed that are copied into project .ddev directory
 project_files:


### PR DESCRIPTION
## The Issue

- #16

## How This PR Solves The Issue

- mongo-express has new v1 release
- add `HTTPS_EXPOSE`
- comment out `MONGO_INITDB_DATABASE` because it has no effect anyway
- do not expand `php${DDEV_PHP_VERSION}-mongodb` to `php8.2-mongodb`

## Manual Testing Instructions

```
ddev get ddev/ddev-mongo
ddev restart
# open mongo-express on 9092 port
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

