### PR TITLE
fix: add `config.mongo.yaml` to project files, fixes #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Mongo Express can now be started on demand using the `ddev mongo-express` comman
 
 ## Caveats:
 
-- The php extension (`phpX.X-mongodb`) is set up in `.ddev/config.mongo.yaml` using `webimage_extra_packages`. You may want to edit your `.ddev/config.yaml` to do what you want and remove the `.ddev/config.mongo.yaml`.
 - You can't define custom MongoDB configuration with this current setup.
 - You can't use `ddev import-db` to import to mongo.
 

--- a/config.mongo.yaml
+++ b/config.mongo.yaml
@@ -1,0 +1,2 @@
+#ddev-generated
+webimage_extra_packages: ["php${DDEV_PHP_VERSION}-mongodb"]

--- a/install.yaml
+++ b/install.yaml
@@ -1,24 +1,19 @@
 name: mongo
 
-pre_install_actions:
-  - |
-    #ddev-description:Create config.mongo.yaml with webimage_extra_packages in it
-    printf '#ddev-generated\nwebimage_extra_packages: ["php${DDEV_PHP_VERSION}-mongodb"]\n' >.ddev/config.mongo.yaml
+project_files:
+  - commands/mongo/mongosh
+  - commands/host/mongo-express
+  - config.mongo.yaml
+  - docker-compose.mongo.yaml
+  - docker-compose.mongo_norouter.yaml
 
 ddev_version_constraint: '>= v1.24.4'
 
 post_install_actions:
   - |
     #ddev-description:If router disabled, directly expose port
-    #
     if ( {{ contains "ddev-router" (list .DdevGlobalConfig.omit_containers | toString) }} ); then
       printf "#ddev-generated\nservices:\n  mongo-express:\n    ports:\n      - 9091:8081\n" > docker-compose.mongo_norouter.yaml
     fi
   - |
     echo "You can now use 'ddev mongo-express' to launch Mongo Express UI"
-
-project_files:
-  - commands/mongo/mongosh
-  - commands/host/mongo-express
-  - docker-compose.mongo.yaml
-  - docker-compose.mongo_norouter.yaml


### PR DESCRIPTION
## The Issue

- Fixes #25

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Adds `config.mongo.yaml` to `project_files`.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-mongo/tarball/refs/pull/27/head
ddev add-on remove mongo
git status
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
