### PR TITLE
feat: add mongo cli tools, use `mongo:latest`, fixes #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ services:
 To change the Docker image:
 
 ```bash
-ddev dotenv set .ddev/.env.mongo --mongo-docker-image=mongo:5-focal
+ddev dotenv set .ddev/.env.mongo --mongo-docker-image=mongo:latest
 ddev add-on get ddev/ddev-mongo
 ddev restart
 ```
@@ -84,7 +84,7 @@ All customization options (use with caution):
 
 | Variable | Flag | Default |
 | -------- | ---- | ------- |
-| `MONGO_DOCKER_IMAGE` | `--mongo-docker-image` | `mongo:5-focal` |
+| `MONGO_DOCKER_IMAGE` | `--mongo-docker-image` | `mongo:latest` |
 | `MONGO_EXPRESS_DOCKER_IMAGE` | `--mongo-express-docker-image` | `mongo-express:1.0` |
 
 ## Credits

--- a/docker-compose.mongo.yaml
+++ b/docker-compose.mongo.yaml
@@ -2,7 +2,7 @@
 services:
   mongo:
     container_name: ddev-${DDEV_SITENAME}-mongo
-    image: ${MONGO_DOCKER_IMAGE:-mongo:5-focal}
+    image: ${MONGO_DOCKER_IMAGE:-mongo:latest}
     volumes:
       - type: "volume"
         source: mongo

--- a/docker-compose.mongo.yaml
+++ b/docker-compose.mongo.yaml
@@ -28,7 +28,7 @@ services:
       # See https://github.com/docker-library/docs/tree/master/mongo#mongo_initdb_database
       # - MONGO_INITDB_DATABASE=db
     healthcheck:
-      test: ["CMD-SHELL", "mongo --eval 'db.runCommand(\"ping\").ok' localhost:27017/test --quiet"]
+      test: ["CMD-SHELL", "mongosh --eval 'db.runCommand(\"ping\").ok' localhost:27017/test --quiet"]
       timeout: 60s
 
   mongo-express:

--- a/docker-compose.mongo.yaml
+++ b/docker-compose.mongo.yaml
@@ -28,7 +28,7 @@ services:
       # See https://github.com/docker-library/docs/tree/master/mongo#mongo_initdb_database
       # - MONGO_INITDB_DATABASE=db
     healthcheck:
-      test: ["CMD-SHELL", "mongosh --eval 'db.runCommand(\"ping\").ok' localhost:27017/test --quiet"]
+      test: ["CMD-SHELL", "M=$(command -v mongosh || command -v mongo) && $$M --eval 'db.runCommand(\"ping\").ok' localhost:27017/test --quiet"]
       timeout: 60s
 
   mongo-express:

--- a/install.yaml
+++ b/install.yaml
@@ -3,6 +3,7 @@ name: mongo
 project_files:
   - commands/mongo/mongosh
   - commands/host/mongo-express
+  - web-build/Dockerfile.mongo
   - config.mongo.yaml
   - docker-compose.mongo.yaml
   - docker-compose.mongo_norouter.yaml

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -47,6 +47,14 @@ health_checks() {
   assert_success
   assert_output --partial '"ok":1'
 
+  # Check mongo CLI utils availability in the "web" container
+  run ddev exec "mongosh 'mongodb://db:db@mongo:27017/test?authSource=admin' --quiet --eval 'JSON.stringify(db.getUsers())'"
+  assert_success
+  assert_output --partial '"ok":1'
+  run ddev exec 'mongodump --version'
+  assert_success
+  assert_output --partial 'mongodump version:'
+
   # Start mongo-express profile
   DDEV_DEBUG=true run ddev mongo-express
   assert_success

--- a/web-build/Dockerfile.mongo
+++ b/web-build/Dockerfile.mongo
@@ -7,6 +7,7 @@ RUN \
     # Add MongoDB GPG key using major version
     wget -qO - https://www.mongodb.org/static/pgp/server-${GPG_VERSION}.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg && \
     # Add repository using the full version
-    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg ] http://repo.mongodb.org/apt/debian $(lsb_release -cs)/mongodb-org/${LATEST_FULL_VERSION} main" > /etc/apt/sources.list.d/mongodb-org-${LATEST_FULL_VERSION}.list && \
+    # Using `bookworm` instead of `$(lsb_release -cs)` because the packages are not yet available for Debian 13 (Trixie)
+    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/${LATEST_FULL_VERSION} main" > /etc/apt/sources.list.d/mongodb-org-${LATEST_FULL_VERSION}.list && \
     apt-get update && \
     apt-get install -y mongodb-mongosh mongodb-database-tools

--- a/web-build/Dockerfile.mongo
+++ b/web-build/Dockerfile.mongo
@@ -1,5 +1,6 @@
 #ddev-generated
 RUN <<EOF
+set -eu -o pipefail
 LATEST_FULL_VERSION=$(curl -s "https://s3.amazonaws.com/repo.mongodb.org?list-type=2&prefix=apt/debian/dists/bookworm/mongodb-org/&delimiter=/" | grep -oP '(?<=<Prefix>)[^<]+mongodb-org/\K[0-9]+\.[0-9]+' | sort -V | tail -1 || echo "8.2")
 # Extract major version for GPG key (e.g., "8.2" -> "8.0")
 MAJOR_VERSION=$(echo "$LATEST_FULL_VERSION" | cut -d. -f1)

--- a/web-build/Dockerfile.mongo
+++ b/web-build/Dockerfile.mongo
@@ -1,3 +1,4 @@
+#ddev-generated
 RUN \
     LATEST_FULL_VERSION=$(curl -s "https://registry.hub.docker.com/v2/repositories/library/mongo/tags/?page_size=100" | jq -r '.results[] | select(.name | test("^[0-9]+\\.[0-9]+$")) | .name' | sort -V | tail -1 || echo "7.0") && \
     # Extract major version for GPG key (e.g., "7.2" -> "7.0")
@@ -7,7 +8,7 @@ RUN \
     # Add MongoDB GPG key using major version
     wget -qO - https://www.mongodb.org/static/pgp/server-${GPG_VERSION}.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg && \
     # Add repository using the full version
-    # Using `bookworm` instead of `$(lsb_release -cs)` because the packages are not yet available for Debian 13 (Trixie)
-    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg ] http://repo.mongodb.org/apt/debian bookworm/mongodb-org/${LATEST_FULL_VERSION} main" > /etc/apt/sources.list.d/mongodb-org-${LATEST_FULL_VERSION}.list && \
-    apt-get update && \
+    KEYRING_PATH="/usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg" && \
+    printf "Types: deb\nURIs: http://repo.mongodb.org/apt/debian\nSuites: bookworm/mongodb-org/${LATEST_FULL_VERSION}\nComponents: main\nSigned-By: ${KEYRING_PATH}\n" > /etc/apt/sources.list.d/mongodb-archive.sources && \
+    (apt-get update || true) && \
     apt-get install -y mongodb-mongosh mongodb-database-tools

--- a/web-build/Dockerfile.mongo
+++ b/web-build/Dockerfile.mongo
@@ -10,7 +10,15 @@ echo "Latest MongoDB version: $LATEST_FULL_VERSION, using GPG key for: $GPG_VERS
 wget -qO - https://www.mongodb.org/static/pgp/server-${GPG_VERSION}.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg
 # Add repository using the full version
 KEYRING_PATH="/usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg"
-printf "Types: deb\nURIs: http://repo.mongodb.org/apt/debian\nSuites: bookworm/mongodb-org/${LATEST_FULL_VERSION}\nComponents: main\nSigned-By: ${KEYRING_PATH}\n" > /etc/apt/sources.list.d/mongodb-archive.sources
+
+cat > /etc/apt/sources.list.d/mongodb-archive.sources <<EOT
+Types: deb
+URIs: http://repo.mongodb.org/apt/debian
+Suites: bookworm/mongodb-org/${LATEST_FULL_VERSION}
+Components: main
+Signed-By: ${KEYRING_PATH}
+EOT
+
 (apt-get update || true)
 apt-get install -y mongodb-mongosh mongodb-database-tools
 EOF

--- a/web-build/Dockerfile.mongo
+++ b/web-build/Dockerfile.mongo
@@ -1,14 +1,15 @@
 #ddev-generated
-RUN \
-    LATEST_FULL_VERSION=$(curl -s "https://s3.amazonaws.com/repo.mongodb.org?list-type=2&prefix=apt/debian/dists/bookworm/mongodb-org/&delimiter=/" | grep -oP '(?<=<Prefix>)[^<]+mongodb-org/\K[0-9]+\.[0-9]+' | sort -V | tail -1 || echo "7.0") && \
-    # Extract major version for GPG key (e.g., "7.2" -> "7.0")
-    MAJOR_VERSION=$(echo "$LATEST_FULL_VERSION" | cut -d. -f1) && \
-    GPG_VERSION="${MAJOR_VERSION}.0" && \
-    echo "Latest MongoDB version: $LATEST_FULL_VERSION, using GPG key for: $GPG_VERSION" && \
-    # Add MongoDB GPG key using major version
-    wget -qO - https://www.mongodb.org/static/pgp/server-${GPG_VERSION}.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg && \
-    # Add repository using the full version
-    KEYRING_PATH="/usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg" && \
-    printf "Types: deb\nURIs: http://repo.mongodb.org/apt/debian\nSuites: bookworm/mongodb-org/${LATEST_FULL_VERSION}\nComponents: main\nSigned-By: ${KEYRING_PATH}\n" > /etc/apt/sources.list.d/mongodb-archive.sources && \
-    (apt-get update || true) && \
-    apt-get install -y mongodb-mongosh mongodb-database-tools
+RUN <<EOF
+LATEST_FULL_VERSION=$(curl -s "https://s3.amazonaws.com/repo.mongodb.org?list-type=2&prefix=apt/debian/dists/bookworm/mongodb-org/&delimiter=/" | grep -oP '(?<=<Prefix>)[^<]+mongodb-org/\K[0-9]+\.[0-9]+' | sort -V | tail -1 || echo "8.2")
+# Extract major version for GPG key (e.g., "8.2" -> "8.0")
+MAJOR_VERSION=$(echo "$LATEST_FULL_VERSION" | cut -d. -f1)
+GPG_VERSION="${MAJOR_VERSION}.0"
+echo "Latest MongoDB version: $LATEST_FULL_VERSION, using GPG key for: $GPG_VERSION"
+# Add MongoDB GPG key using major version
+wget -qO - https://www.mongodb.org/static/pgp/server-${GPG_VERSION}.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg
+# Add repository using the full version
+KEYRING_PATH="/usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg"
+printf "Types: deb\nURIs: http://repo.mongodb.org/apt/debian\nSuites: bookworm/mongodb-org/${LATEST_FULL_VERSION}\nComponents: main\nSigned-By: ${KEYRING_PATH}\n" > /etc/apt/sources.list.d/mongodb-archive.sources
+(apt-get update || true)
+apt-get install -y mongodb-mongosh mongodb-database-tools
+EOF

--- a/web-build/Dockerfile.mongo
+++ b/web-build/Dockerfile.mongo
@@ -1,0 +1,12 @@
+RUN \
+    LATEST_FULL_VERSION=$(curl -s "https://registry.hub.docker.com/v2/repositories/library/mongo/tags/?page_size=100" | jq -r '.results[] | select(.name | test("^[0-9]+\\.[0-9]+$")) | .name' | sort -V | tail -1 || echo "7.0") && \
+    # Extract major version for GPG key (e.g., "7.2" -> "7.0")
+    MAJOR_VERSION=$(echo "$LATEST_FULL_VERSION" | cut -d. -f1) && \
+    GPG_VERSION="${MAJOR_VERSION}.0" && \
+    echo "Latest MongoDB version: $LATEST_FULL_VERSION, using GPG key for: $GPG_VERSION" && \
+    # Add MongoDB GPG key using major version
+    wget -qO - https://www.mongodb.org/static/pgp/server-${GPG_VERSION}.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg && \
+    # Add repository using the full version
+    echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg ] http://repo.mongodb.org/apt/debian $(lsb_release -cs)/mongodb-org/${LATEST_FULL_VERSION} main" > /etc/apt/sources.list.d/mongodb-org-${LATEST_FULL_VERSION}.list && \
+    apt-get update && \
+    apt-get install -y mongodb-mongosh mongodb-database-tools

--- a/web-build/Dockerfile.mongo
+++ b/web-build/Dockerfile.mongo
@@ -1,6 +1,6 @@
 #ddev-generated
 RUN \
-    LATEST_FULL_VERSION=$(curl -s "https://registry.hub.docker.com/v2/repositories/library/mongo/tags/?page_size=100" | jq -r '.results[] | select(.name | test("^[0-9]+\\.[0-9]+$")) | .name' | sort -V | tail -1 || echo "7.0") && \
+    LATEST_FULL_VERSION=$(curl -s "https://s3.amazonaws.com/repo.mongodb.org?list-type=2&prefix=apt/debian/dists/bookworm/mongodb-org/&delimiter=/" | grep -oP '(?<=<Prefix>)[^<]+mongodb-org/\K[0-9]+\.[0-9]+' | sort -V | tail -1 || echo "7.0") && \
     # Extract major version for GPG key (e.g., "7.2" -> "7.0")
     MAJOR_VERSION=$(echo "$LATEST_FULL_VERSION" | cut -d. -f1) && \
     GPG_VERSION="${MAJOR_VERSION}.0" && \


### PR DESCRIPTION
## The Issue

- Fixes #29

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

- Adds mongo cli tools
- Switches from `mongo:5-focal` to `mongo:latest`

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-mongo/tarball/refs/pull/30/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->