### PR TITLE
feat: Create the `db` database by default on the first start

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ ddev restart
 
 After installation, make sure to commit the `.ddev` directory to version control.
 
+## Connection
+
+By default, the database with the name `db` is created. You can connect to it using this connection string:
+```
+mongodb://db:db@mongo/db?authSource=admin
+```
+You can change the default database name, username, and password using env variables:
+```
+MONGO_INITDB_ROOT_USERNAME=db
+MONGO_INITDB_ROOT_PASSWORD=db
+MONGO_INITDB_DATABASE=db
+```
+
 ## Configuration
 
 1. Your project will likely require the [Doctrine MongoDB ODM bundle](https://github.com/doctrine/DoctrineMongoDBBundle)

--- a/README.md
+++ b/README.md
@@ -25,15 +25,9 @@ After installation, make sure to commit the `.ddev` directory to version control
 ## Connection
 
 By default, the database with the name `db` is created. You can connect to it using this connection string:
-```
+
+```text
 mongodb://db:db@mongo/db?authSource=admin
-```
-You can change the default database name, username, and password using env variables:
-```
-MONGO_INITDB_ROOT_USERNAME=db
-MONGO_INITDB_ROOT_PASSWORD=db
-MONGO_INITDB_DATABASE=db
-```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ By default, the database with the name `db` is created. You can connect to it us
 
 ```text
 mongodb://db:db@mongo/db?authSource=admin
+```
+
+You can change the default database name, username, and password using env variables:
+
+```bash
+ddev dotenv set .ddev/.env.mongo \
+    --mongo-initdb-root-username=db \
+    --mongo-initdb-root-password=db \
+    --mongo-initdb-database=db
+```
+
+If default authentication is not required, see the [Advanced Customization](#advanced-customization) section below.
 
 ## Configuration
 

--- a/docker-compose.mongo.yaml
+++ b/docker-compose.mongo.yaml
@@ -23,11 +23,11 @@ services:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
     environment:
-      - MONGO_INITDB_ROOT_USERNAME=db
-      - MONGO_INITDB_ROOT_PASSWORD=db
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME:-db}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD:-db}
       # The database name to create on the first start.
       # See https://github.com/docker-library/docs/tree/master/mongo#mongo_initdb_database
-      - MONGO_INITDB_DATABASE=db
+      - MONGO_INITDB_DATABASE=${MONGO_INITDB_DATABASE:-db}
     healthcheck:
       test: ["CMD-SHELL", "M=$(command -v mongosh || command -v mongo) && $$M --eval 'db.runCommand(\"ping\").ok' localhost:27017/test --quiet"]
       timeout: 60s

--- a/docker-compose.mongo.yaml
+++ b/docker-compose.mongo.yaml
@@ -25,8 +25,9 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=db
       - MONGO_INITDB_ROOT_PASSWORD=db
+      # The database name to create on the first start.
       # See https://github.com/docker-library/docs/tree/master/mongo#mongo_initdb_database
-      # - MONGO_INITDB_DATABASE=db
+      - MONGO_INITDB_DATABASE=db
     healthcheck:
       test: ["CMD-SHELL", "M=$(command -v mongosh || command -v mongo) && $$M --eval 'db.runCommand(\"ping\").ok' localhost:27017/test --quiet"]
       timeout: 60s


### PR DESCRIPTION
## The Issue

For now, when the add-on is installed for the first time, no database is created, which confuses people. 
The Mongo add-on is usually installed to use a database in the project, right? ;)

## How This PR Solves The Issue

So, let's create by default a database with the name `db` (follow the DDEV database name convention), as most of the other database DDEV addons do.

Also, let's clarify what connection string to use for connecting to the default database, cuz many users have a hard time understanding nuances in the database access configuration, especially the `?authSource=admin` part of the connection string.

## Manual Testing Instructions

1. Add the add-on to an empty DDEV project.
```bash
ddev add-on get https://github.com/ddev/ddev-mongo/tarball/refs/pull/33/head
ddev restart
```

2. See that the `db` database was created by default.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
