### PR TITLE
fix(arm64): switch repo from Debian 12 to Ubuntu 24.04, fixes #35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,23 @@ yaml` file, along with all files specified under `project_files` within `install
 
 ---
 
+## [v2.3.2](https://github.com/ddev/ddev-mongo/releases/tag/v2.3.2) - 2026-02-11
+[_Compare with previous release_](https://github.com/ddev/ddev-mongo/compare/v2.3.1...v2.3.2)
+
+### Changed
+
+- Fix `mongodb-database-tools` installation on arm64 by using Ubuntu 24.04 repository
+
+---
+
 ## [v2.3.1](https://github.com/ddev/ddev-mongo/releases/tag/v2.3.1) - 2026-02-03
 [_Compare with previous release_](https://github.com/ddev/ddev-mongo/compare/v2.3.0...v2.3.1)
 
 ### Changed
 
 - Use `MONGO_INITDB_DATABASE=db` to create a default database.
+
+---
 
 ## [v2.3.0](https://github.com/ddev/ddev-mongo/releases/tag/v2.3.0) - 2026-01-28
 [_Compare with previous release_](https://github.com/ddev/ddev-mongo/compare/v2.2.1...v2.3.0)

--- a/web-build/Dockerfile.mongo
+++ b/web-build/Dockerfile.mongo
@@ -1,21 +1,22 @@
 #ddev-generated
 RUN <<EOF
 set -eu -o pipefail
-LATEST_FULL_VERSION=$(curl -s "https://s3.amazonaws.com/repo.mongodb.org?list-type=2&prefix=apt/debian/dists/bookworm/mongodb-org/&delimiter=/" | grep -oP '(?<=<Prefix>)[^<]+mongodb-org/\K[0-9]+\.[0-9]+' | sort -V | tail -1 || echo "8.2")
+LATEST_FULL_VERSION=$(curl -s "https://s3.amazonaws.com/repo.mongodb.org?list-type=2&prefix=apt/ubuntu/dists/noble/mongodb-org/&delimiter=/" | grep -oP '(?<=<Prefix>)[^<]+mongodb-org/\K[0-9]+\.[0-9]+' | sort -V | tail -1 || echo "8.2")
+
 # Extract major version for GPG key (e.g., "8.2" -> "8.0")
 MAJOR_VERSION=$(echo "$LATEST_FULL_VERSION" | cut -d. -f1)
 GPG_VERSION="${MAJOR_VERSION}.0"
-echo "Latest MongoDB version: $LATEST_FULL_VERSION, using GPG key for: $GPG_VERSION"
-# Add MongoDB GPG key using major version
-wget -qO - https://www.mongodb.org/static/pgp/server-${GPG_VERSION}.asc | gpg --dearmor -o /usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg
-# Add repository using the full version
 KEYRING_PATH="/usr/share/keyrings/mongodb-server-${GPG_VERSION}.gpg"
 
-cat > /etc/apt/sources.list.d/mongodb-archive.sources <<EOT
+# Add MongoDB GPG key using major version
+wget -qO - https://www.mongodb.org/static/pgp/server-${GPG_VERSION}.asc | gpg --dearmor -o "${KEYRING_PATH}"
+
+# Add repository using the full version
+cat > /etc/apt/sources.list.d/mongodb-server.sources <<EOT
 Types: deb
-URIs: http://repo.mongodb.org/apt/debian
-Suites: bookworm/mongodb-org/${LATEST_FULL_VERSION}
-Components: main
+URIs: http://repo.mongodb.org/apt/ubuntu
+Suites: noble/mongodb-org/${LATEST_FULL_VERSION}
+Components: multiverse
 Signed-By: ${KEYRING_PATH}
 EOT
 


### PR DESCRIPTION
## The Issue

- Fixes #35

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Uses Ubuntu 24.04, which has `mongodb-database-tools` available.

## Manual Testing Instructions

Using ARM64:

```bash
ddev add-on get https://github.com/ddev/ddev-mongo/tarball/refs/pull/36/head
ddev restart
ddev exec mongodump --version
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
